### PR TITLE
omxplayer: fix an error caused by new srcrev fetcher API

### DIFF
--- a/recipes-multimedia/omxplayer/omxplayer_git.bb
+++ b/recipes-multimedia/omxplayer/omxplayer_git.bb
@@ -11,6 +11,8 @@ DEPENDS = "alsa-lib libpcre virtual/egl boost freetype dbus openssl libssh virtu
 
 PR = "r6"
 
+SRCREV_FORMAT = "_ffmpeg"
+
 SRCREV_default = "1f1d0ccd65d3a1caa86dc79d2863a8f067c8e3f8"
 
 # omxplayer builds its own copy of ffmpeg from source instead of using the


### PR DESCRIPTION
Fail to parse omxplayer_git.bb after using new srcrev fetcher API
* https://git.yoctoproject.org/poky/commit/?id=c9400d01575c2a93762b71bf790d0edd6e2acb6f
* https://git.yoctoproject.org/poky/commit/?id=62afa02d01794376efab75623f42e7e08af08526

Error message:

ERROR: ExpansionError during parsing /tmp/meta-raspberrypi/recipes-multimedia/omxplayer/omxplayer_git.bb Traceback (most recent call last):
  File "Var <fetcher_hashes_dummyfunc[vardepvalue]>", line 1, in <module>
  File "/tmp/poky/bitbake/lib/bb/fetch2/__init__.py", line 834, in get_hashvalue(d=<bb.data_smart.DataSmart object at 0x7fdac34c1130>, method_name='sortable_revision'):
     def get_hashvalue(d, method_name='sortable_revision'):
    >    pkgv, revs = _get_srcrev(d, method_name=method_name)
         return " ".join(revs)
  File "/tmp/poky/bitbake/lib/bb/fetch2/__init__.py", line 804, in _get_srcrev(d=<bb.data_smart.DataSmart object at 0x7fdac34c1130>, method_name='sortable_revision'):
         if not format:
    >        raise FetchError("The SRCREV_FORMAT variable must be set when multiple SCMs are used.\n"\
                              "The SCMs are:\n%s" % '\n'.join(scms))
bb.data_smart.ExpansionError: Failure expanding variable fetcher_hashes_dummyfunc[vardepvalue], expression was ${@bb.fetch.get_hashvalue(d)} which triggered exception FetchError: Fetcher failure: The SRCREV_FORMAT variable must be set when multiple SCMs are used. The SCMs are:
git://github.com/popcornmix/omxplayer.git;protocol=https;branch=master git://github.com/FFmpeg/FFmpeg;branch=release/4.0;protocol=https;depth=1;name=ffmpeg;destsuffix=git/ffmpeg The variable dependency chain for the failure is: fetcher_hashes_dummyfunc[vardepvalue]

ERROR: Parsing halted due to errors, see error messages above

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**
fix an error caused by new srcrev fetcher API

**- How I did it**
Add SRCREV_FORMAT to omxplayer_git.bb
